### PR TITLE
chore: bump sphinx-revealjs[screenshot] from 2.9.3 to 2.7.1

### DIFF
--- a/pyvista-tutorial/requirements.txt
+++ b/pyvista-tutorial/requirements.txt
@@ -1,5 +1,5 @@
 oEmbedPy==0.4.0
-sphinx-revealjs[screenshot]==2.9.3
+sphinx-revealjs[screenshot]==2.7.1
 sphinx-tabs==3.4.5
 sphinx_design==0.5.0
 sphinxcontrib-gtagjs==0.2.1


### PR DESCRIPTION
chore: bump sphinx-revealjs[screenshot] from 2.9.3 to 2.7.1.