### PR TITLE
Start Python Clubの管理者からのレビュー

### DIFF
--- a/startpython2024/index.rst
+++ b/startpython2024/index.rst
@@ -108,7 +108,7 @@ PyVistaとは？
 
 .. code-block:: bash
 
-   $ pip install pyvista[all]
+   $ pip install "pyvista[all]"
 
 モデリングをしてみよう
 ======================


### PR DESCRIPTION
- インストールの際にダブルクオテーションを追加する必要のあるシェルがあります。